### PR TITLE
roots/1 can now return complex numbers.

### DIFF
--- a/src/linalg_complex.erl
+++ b/src/linalg_complex.erl
@@ -1,0 +1,133 @@
+-module(linalg_complex).
+-vsn('1.0').
+-author('tiago.klassen').
+-define(SMALL, 1.0e-10).
+
+-export([sqrt/1, qbrt/1]). 
+-export([add/1, add/2, mltp/1, mltp/2, reciprocal/1, min/1, max/1]).
+
+-type complex_tuple() :: {Real::number(), Imaginary::number()}.
+-type complex() :: Real::number() | complex_tuple().
+
+-spec sqrt(complex()) -> complex().
+sqrt(Real) when is_number(Real) ->
+    sqrt({Real, 0});
+sqrt({Real, Imaginary}) when abs(Imaginary) < ?SMALL ->
+    if
+        abs(Real) < ?SMALL -> 0;
+        Real > 0 -> math:sqrt(Real);
+        Real < 0 -> {0, math:sqrt(-Real)}
+    end;
+sqrt(Complex) ->
+    % yes, there is a way to solve this. but not now.
+    error(non_real_number_sqrt, Complex).
+
+-spec qbrt(complex()) -> complex().
+qbrt(Complex) ->
+    W = {-1/2, sqrt(3)/2},
+    Ans0 = qbrt1(Complex),
+    Ans1 = mltp(Ans0, W),
+    Ans2 = mltp(Ans1, W),
+    if
+        is_number(Ans0) -> Ans0;
+        is_number(Ans1) -> Ans1;
+        is_number(Ans2) -> Ans2;
+        true -> max([Ans0,Ans1,Ans2])
+    end.
+qbrt1(Real) when is_number(Real) ->
+    qbrt1({Real, 0});
+qbrt1({Real, Imaginary}) when abs(Imaginary) < ?SMALL ->
+    if
+        abs(Real) < ?SMALL ->
+            0;
+        Real > 0 -> 
+            math:pow(Real, 1/3);
+        Real < 0 ->
+            P = math:pow(-Real, 1/3),
+            Q = math:pi()/3,
+            to_complex({P*math:cos(Q), P*math:sin(Q)})
+    end;
+qbrt1({R, I}) when abs(R) < ?SMALL ->
+    P = math:pow(abs(I), 1/3),
+    Q = I/abs(I) * math:pi()/6,
+    to_complex(mltp(P, {math:cos(Q), math:sin(Q)}));
+qbrt1({R, I}) ->
+    P = math:pow(R*R+I*I, 1/6),
+    {Np, Q} = case {R>0, I>0} of
+        {true, true} -> {1, 1/3*math:atan(I/R)};
+        {false, true} -> {1, 1/3*(math:pi()-math:atan(I/abs(R)))};
+        {true, false} -> {-1, 1/3*math:atan(abs(I)/R)};
+        {false, false} -> {1, 1/3*(math:atan(abs(I)/abs(R))-math:pi())}
+    end,
+    to_complex({P*math:cos(Q), Np*P*math:sin(Q)}).
+
+-spec add([complex(), ...]) -> complex().
+add(ComplexList) ->
+    FoldFun = fun(X, Prev) -> add(X, Prev) end,
+    lists:foldl(FoldFun, 0, ComplexList).
+
+-spec add(complex(), complex()) -> complex().
+add(A, B) ->
+    {Ar, Ai} = to_tuple(A),
+    {Br, Bi} = to_tuple(B),
+    to_complex({Ar+Br, Ai+Bi}).
+
+-spec mltp([complex(), ...]) -> complex().
+mltp(ComplexList) ->
+    FoldFun = fun(X, Prev) -> mltp(X, Prev) end,
+    lists:foldl(FoldFun, 1, ComplexList).
+
+-spec mltp(complex(), complex()) -> complex().
+mltp(A, B) ->
+    {Ar, Ai} = to_tuple(A),
+    {Br, Bi} = to_tuple(B),
+    to_complex({Ar*Br-Ai*Bi, Ar*Bi+Br*Ai}).
+
+-spec reciprocal(complex()) -> complex().
+reciprocal(A) ->
+    {Real, Imaginary} = to_tuple(A),
+    R2I2 = Real*Real + Imaginary*Imaginary,
+    to_complex({Real/R2I2, -Imaginary/R2I2}).
+
+-spec angle(complex()) -> number().
+angle(Real) when is_number(Real) ->
+    if
+        Real>0 -> 0;
+        Real<0 -> math:pi()
+    end;
+angle({Real,Imaginary}) ->
+    R = Real / sqrt(Real*Real + Imaginary*Imaginary),
+    I = Imaginary / sqrt(Real*Real + Imaginary*Imaginary),
+    if
+        I>=0 -> math:acos(R);
+        I<0 -> 2*math:pi() - math:acos(R)
+    end.
+
+-spec min([complex(), ...]) -> complex().
+min([H|T]) ->
+    to_complex(find_minmax(min, T, H)).
+
+-spec max([complex(), ...]) -> complex().
+max([H|T]) ->
+    to_complex(find_minmax(max, T, H)).
+
+find_minmax(MinMax, [], Ans) ->
+    Ans;
+find_minmax(MinMax, [Complex|Next], Prev) ->
+    {C, Ci} = to_tuple(Complex),
+    {P, Pi} = to_tuple(Prev),
+    if
+        MinMax==max, C > P -> find_minmax(MinMax, Next, Complex);
+        MinMax==min, C < P -> find_minmax(MinMax, Next, Complex);
+        MinMax==max, C==P, Ci > Pi -> find_minmax(MinMax, Next, Complex);
+        MinMax==min, C==P, Ci < Pi -> find_minmax(MinMax, Next, Complex);
+        true -> find_minmax(MinMax, Next, Prev)
+    end.
+
+-spec to_tuple(complex()) -> complex_tuple().
+to_tuple({Real, Imaginary}) -> {Real, Imaginary};
+to_tuple(Real) -> {Real, 0}.
+
+-spec to_complex(complex()) -> complex().
+to_complex({Real, Imaginary}) when abs(Imaginary) < ?SMALL -> Real;
+to_complex(Complex) -> Complex.

--- a/src/linalg_roots.erl
+++ b/src/linalg_roots.erl
@@ -1,7 +1,9 @@
 -module(linalg_roots).
 -vsn('1.0').
 -author('simon.klassen').
--import(math, [pi/0, acos/1, cos/1, sqrt/1, pow/2]).
+-import(math, [pi/0, acos/1, cos/1, pow/2]).
+-import(linalg_complex, [sqrt/1, qbrt/1]).
+-import(linalg_complex, [add/1, add/2, mltp/1, mltp/2, reciprocal/1]).
 -export([roots/1]).
 -define(SMALL, 1.0e-10).
 
@@ -23,38 +25,41 @@ roots([A, B]) ->
 % well known closed form
 % ax^2 + bx + c = 0
 roots([A, B, C]) ->
-    Q = -0.5 * (B + sign(1, B) * sqrt(B * B - 4 * A * C)),
-    X1 = Q / A,
-    X2 = C / Q,
-    [min(X1, X2), max(X1, X2)];
+    Denom = reciprocal(mltp(2,A)), % 1/(2*A)
+    P = mltp(Denom, -B), % -b/(2*A)
+    % Q = sqrt(B^2-4*A*C)/(2*A)
+    Q = mltp(Denom, sqrt(add(mltp(B, B), mltp([-4, A, C])))),
+    lists:usort([add(P, Q), add(P, mltp(-1, Q))]); % P +/- Q
 % cubic polynomial
 % viete
-% x^3 + ax^2 + bx +c = 0
-roots([1, A, B, C]) ->
-    Q = (A * A - 3 * B) / 9,
-    R = (2 * A * A * A - 9 * A * B + 27 * C) / 54,
-
-    Q3 = Q * Q * Q,
-    R2 = R * R,
-
-    case R2 < Q3 of
-      true ->
-        % three real roots
-        TH = acos(R / sqrt(Q3)),
-        SqrtQ = sqrt(Q),
-        X1 = -2 * SqrtQ * cos(TH / 3) - A / 3,
-        X2 = -2 * SqrtQ * cos((TH + 2 * pi()) / 3) - A / 3,
-        X3 = -2 * SqrtQ * cos((TH - 2 * pi()) / 3) - A / 3,
-        lists:usort([X1, X2, X3]);
-      false ->
-        % one real root
-        Alpha = -sign(1, R) * pow(abs(R) + sqrt(R2 - Q3), 1 / 3),
-        Beta = case abs(Alpha) <?SMALL of
-                 true -> 0;
-                 false -> Q / Alpha
-               end,
-        [(Alpha + Beta) - A / 3]
-    end;
+% x^3 + bx^2 + cx +d = 0
+roots([1, B, C, D]) ->
+    P = mltp(-1/3, B), % -b/3
+    % Q = (-2B^3+9BC-27D)/54
+    Q = mltp(1/54, add([mltp([-2,B,B,B]), mltp([9, B, C]), mltp(-27, D)])),
+    % R = sqrt(3*(27D^2-18BCD+4B^3D+4C^3-B^2C^2))/18
+    R = mltp(1/18, sqrt(mltp(3, add([
+        mltp([27,D,D]), mltp([-18,B,C,D]),
+        mltp([4,B,B,B,D]), mltp([4,C,C,C]), mltp([-1,B,B,C,C])
+    ])))),
+    
+    % Wp = (-1+sqrt(3)i)/2
+    % Wn = (-1-sqrt(3)i)/2
+    Wp = {-1/2, sqrt(3)/2},
+    Wn = {-1/2, -sqrt(3)/2},
+    
+    % QpR = qbrt(Q+R)
+    % QnR = qbrt(Q-R)
+    QpR = qbrt(add(Q, R)),
+    QnR = qbrt(add(Q, mltp(-1, R))),
+    
+    % X1 = P + QpR + QnR
+    % X2 = P + Wp * QpR + Wn * QnR
+    % X3 = P + Wn * QpR + Wp * QnR
+    X1 = add([P, QpR, QnR]),
+    X2 = add([P, mltp(Wp, QpR), mltp(Wn, QnR)]),
+    X3 = add([P, mltp(Wn, QpR), mltp(Wp, QnR)]),
+    lists:usort([X1, X2, X3]);
 roots([A, B, C, D]) ->
   roots([1, B/A, C/A, D/A]).
 

--- a/src/linalg_roots.erl
+++ b/src/linalg_roots.erl
@@ -7,8 +7,9 @@
 -export([roots/1]).
 -define(SMALL, 1.0e-10).
 
--type vector() :: list(float).
--spec roots(vector()) -> vector().
+-type vector() :: list(number()).
+-type complex() :: Real::number() | {Real::number(), Imaginary::number()}.
+-spec roots(vector()) -> complex().
 % null case
 roots([]) ->
     [];

--- a/test/linalg_complex_tests.erl
+++ b/test/linalg_complex_tests.erl
@@ -1,0 +1,97 @@
+-module(linalg_complex_tests).
+-import(linalg_complex, [sqrt/1, qbrt/1]).
+-import(linalg_complex, [add/1, add/2, mltp/1, mltp/2, reciprocal/1]).
+-define(NODEBUG, true). % Define NODEBUG for a quiet test.
+-include_lib("eunit/include/eunit.hrl").
+-define(PRECISION,1000000).
+
+complex_sqrt_1_test() ->
+    ?assertEqual(0, sqrt(0)),
+    ?assertEqual(0, sqrt({0,0})),
+    ?assertEqual(2.0, sqrt(4)),
+    ?assertEqual(2.0, sqrt({4,0})),
+    ?assertEqual({0,2.0}, sqrt(-4)),
+    ?assertEqual({0,2.0}, sqrt({-4,0})).
+
+complex_qbrt_1_test() ->
+    ?assertEqual(0, qbrt(0)),
+    ?assertEqual(0, qbrt({0,0})),
+    ?assertEqual(2.0, qbrt(8)),
+    ?assertEqual(2.0, qbrt({8,0})),
+    ?assertEqual([
+        -1.709976, % -5
+        {1.480883, 0.854988}, % {0,5}
+        {1.480883, -0.854988}, % {0,-5}
+        {1.451857, 0.493404}, % {2,3}
+        {1.153228, 1.010643}, % {-2,3}
+        {1.451857, -0.493404}, % {2,-3}
+        {1.153228, -1.010643} % {-2,-3}
+    ], approx([
+        qbrt(-5),
+        qbrt({0,5}),
+        qbrt({0,-5}),
+        qbrt({2,3}),
+        qbrt({-2,3}),
+        qbrt({2,-3}),
+        qbrt({-2,-3})
+    ])).
+
+complex_add_1_test() ->
+    ?assertEqual({7,8}, add([1, {2,0}, {0,3}, {4,5}])).
+
+complex_add_2_test() ->
+    ?assertEqual(3, add(1, 2)),
+    ?assertEqual(3, add({1,0}, 2)),
+    ?assertEqual(3, add(1, {2,0})),
+    ?assertEqual(3, add({1,0}, {2,0})),
+    ?assertEqual({3,9}, add({1,4}, {2,5})),
+    ?assertEqual({-4,2}, add({1,4}, {-5,-2})),
+    ?assertEqual({6.8,11.2}, add({1.2,3.4}, {5.6,7.8})).
+
+complex_mltp_1_test() ->
+    ?assertEqual({-196,83}, mltp([{2,3},{4,5},{6,7}])).
+
+complex_mltp_2_test() ->
+    ?assertEqual(6, mltp(3, 2)),
+    ?assertEqual(6, mltp({3,0}, 2)),
+    ?assertEqual(6, mltp(3, {2,0})),
+    ?assertEqual(6, mltp({3,0}, {2,0})),
+    ?assertEqual({-14, 23}, mltp({3,4}, {2,5})),
+    ?assertEqual([{-15.55, 26.4}], approx([mltp({3.1,4.2}, {2.3,5.4})])).
+
+complex_reciprocal_2_test() ->
+    ?assertEqual(
+        [0.5, 0.5, 0.4, 0.4, {0.153846, -0.230769}, {0.160932, 0.172031}],
+        approx([
+            reciprocal(2),
+            reciprocal({2, 0}),
+            reciprocal(2.5),
+            reciprocal({2.5, 0}),
+            reciprocal({2, 3}),
+            reciprocal({2.9, -3.1})
+        ])
+    ).
+
+complex_min_test() ->
+    ?assertEqual({-10,-10}, linalg_complex:min([
+        -1, 0, 1, {-10,-10}, {-10,0}, {-10,10}, {0,-10}, {0,0}, 
+        {10,-10}, {10,0}, {10,10}, 1, 0, -1, {0,0}
+    ])).
+
+complex_max_test() ->
+    ?assertEqual({10,10}, linalg_complex:max([
+        -1, 0, 1, {-10,-10}, {-10,0}, {-10,10}, {0,-10}, {0,0}, 
+        {10,-10}, {10,0}, {10,10}, 1, 0, -1, {0,0}
+    ])).
+
+approx(Fs) ->
+    approx(Fs,[]).
+approx([],Acc) ->
+    lists:reverse(Acc);
+approx([{Real,Imaginary}|Tail],Acc) ->
+    approx(Tail,[{
+        round(Real*?PRECISION)/?PRECISION,
+        round(Imaginary*?PRECISION)/?PRECISION
+    }|Acc]);
+approx([Real|Tail],Acc) ->
+    approx(Tail,[round(Real*?PRECISION)/?PRECISION|Acc]).


### PR DESCRIPTION
Also added `linalg_complex` module.

TODO: implement `sqrt(Complex::{number(), non_zero_integer()})`.
TODO: extend `roots([number()]) -> complex()` to `roots([complex()]) -> complex()`

`linalg_roots_tests:assert_roots/1` will no longer try...catch `linalg:roots/1`.
If `linalg:roots/1` throws an error, the test will fail.