### PR TITLE
merge arithmetic operations of matrix and complex

### DIFF
--- a/src/linalg.erl
+++ b/src/linalg.erl
@@ -349,10 +349,7 @@ divide(M1, M2) ->
         M1,
         M2,
         fun(A, B) ->
-            case B==0 of
-                true -> ?NA;
-                false -> linalg_complex:'/'(A, B)
-            end
+            linalg_complex:'/'(A, B)
         end,
         []
     ).

--- a/src/linalg.erl
+++ b/src/linalg.erl
@@ -336,13 +336,13 @@ imag(M)->
     sig1(M, fun(X) -> case X of {_R,I}->I; _-> 0 end end, []).
 
 add(M1, M2) ->
-    sig2(M1, M2, fun(A, B) -> A + B end, []).
+    sig2(M1, M2, fun(A, B) -> linalg_complex:'+'(A, B) end, []).
 
 sub(M1, M2) ->
-    sig2(M1, M2, fun(A, B) -> A - B end, []).
+    sig2(M1, M2, fun(A, B) -> linalg_complex:'-'(A, B) end, []).
 
 mul(M1, M2) ->
-    sig2(M1, M2, fun(A, B) -> A * B end, []).
+    sig2(M1, M2, fun(A, B) -> linalg_complex:'*'(A, B) end, []).
 
 divide(M1, M2) ->
     sig2(
@@ -351,7 +351,7 @@ divide(M1, M2) ->
         fun(A, B) ->
             case B==0 of
                 true -> ?NA;
-                false -> A / B
+                false -> linalg_complex:'/'(A, B)
             end
         end,
         []
@@ -587,7 +587,9 @@ sig2(A, [R2 | M2], Fun, Acc) when is_number(A) ->
 sig2([R1 | M1], B, Fun, Acc) when is_number(B) ->
     sig2(M1, B, Fun, [[Fun(A, B) || A <- R1] | Acc]);
 sig2([R1 | M1], [R2 | M2], Fun, Acc) ->
-    sig2(M1, M2, Fun, [[Fun(A, B) || {A, B} <- lists:zip(R1, R2)] | Acc]).
+    sig2(M1, M2, Fun, [[Fun(A, B) || {A, B} <- lists:zip(R1, R2)] | Acc]);
+sig2(A, B, Fun, []) ->
+    Fun(A, B).
 
 reduction([], _Fun, Init) ->
     Init;

--- a/src/linalg_complex.erl
+++ b/src/linalg_complex.erl
@@ -145,13 +145,13 @@ to_float(Float) when is_float(Float) -> Float.
 %% +-*/
 '+'(Z) when is_number(Z) -> Z;
 '+'(Z) -> Z.
-'+'(Z0, Z1) when is_number(Z0), is_number(Z0) -> Z0 + Z1;
+'+'(Z0, Z1) when is_number(Z0), is_number(Z1) -> Z0 + Z1;
 '+'(Z0, Z1) -> sum(Z0, Z1).
 '-'(Z) when is_number(Z) -> -Z;
 '-'(Z) -> mltp(-1, Z).
-'-'(Z0, Z1) when is_number(Z0), is_number(Z0) -> Z0 - Z1;
+'-'(Z0, Z1) when is_number(Z0), is_number(Z1) -> Z0 - Z1;
 '-'(Z0, Z1) -> sum(Z0, mltp(-1, Z1)).
-'*'(Z0, Z1) when is_number(Z0), is_number(Z0) -> Z0 * Z1;
+'*'(Z0, Z1) when is_number(Z0), is_number(Z1) -> Z0 * Z1;
 '*'(Z0, Z1) -> mltp(Z0, Z1).
-'/'(Z0, Z1) when is_number(Z0), is_number(Z0) -> Z0 / Z1;
+'/'(Z0, Z1) when is_number(Z0), is_number(Z1) -> Z0 / Z1;
 '/'(Z0, Z1) -> mltp(Z0, reciprocal(Z1)).

--- a/src/linalg_complex.erl
+++ b/src/linalg_complex.erl
@@ -153,5 +153,9 @@ to_float(Float) when is_float(Float) -> Float.
 '-'(Z0, Z1) -> sum(Z0, mltp(-1, Z1)).
 '*'(Z0, Z1) when is_number(Z0), is_number(Z1) -> Z0 * Z1;
 '*'(Z0, Z1) -> mltp(Z0, Z1).
+'/'(Z0, Z1) when is_number(Z0), is_number(Z1), Z0==0, Z1==0 ->
+    error({indeterminate_form, {divide, [Z0,Z1]}});
+'/'(Z0, Z1) when is_number(Z0), is_number(Z1), Z1==0 ->
+    throw(complex_infinity);
 '/'(Z0, Z1) when is_number(Z0), is_number(Z1) -> Z0 / Z1;
 '/'(Z0, Z1) -> mltp(Z0, reciprocal(Z1)).

--- a/src/linalg_complex.erl
+++ b/src/linalg_complex.erl
@@ -5,7 +5,8 @@
 
 -export([to_polar/1, from_polar/1]).
 -export([exp/1, ln/1, pow/2, sqrt/1, qbrt/1, absolute/1, arg/1]). 
--export([add/1, add/2, mltp/1, mltp/2, reciprocal/1, usort/1]).
+-export([sum/1, sum/2, mltp/1, mltp/2, reciprocal/1, usort/1]).
+-export(['+'/1, '+'/2, '-'/1, '-'/2, '*'/2, '/'/2]).
 
 -type non_neg_real() :: number(). % but not negative please.
 -type angle() :: number(). % principal value is -PI < argZ =< PI
@@ -63,13 +64,13 @@ absolute({R,I}) when is_number(R), is_number(I) ->
 absolute(R) when is_number(R) ->
     0.0+abs(R).
 
--spec add([complex(), ...]) -> complex().
-add(ComplexList) ->
-    FoldFun = fun(X, Prev) -> add(X, Prev) end,
+-spec sum([complex(), ...]) -> complex().
+sum(ComplexList) ->
+    FoldFun = fun(X, Prev) -> sum(X, Prev) end,
     lists:foldl(FoldFun, 0, ComplexList).
 
--spec add(complex(), complex()) -> complex().
-add(A, B) ->
+-spec sum(complex(), complex()) -> complex().
+sum(A, B) ->
     {Ar, Ai} = to_tuple(A),
     {Br, Bi} = to_tuple(B),
     to_complex({Ar+Br, Ai+Bi}).
@@ -116,8 +117,8 @@ usort([]) -> [];
 usort(List) when is_list(List) ->
     [Head|Tail] = lists:usort(List),
     FoldFun = fun(X, {[Y|Prev], C}) ->
-        case absolute(add(X,mltp(-1,Y))) < ?SMALL of
-            true -> {[mltp(1/(C+1),add(X,mltp(C,Y)))|Prev], C+1};
+        case absolute(sum(X,mltp(-1,Y))) < ?SMALL of
+            true -> {[mltp(1/(C+1),sum(X,mltp(C,Y)))|Prev], C+1};
             false -> {[X|[Y|Prev]], 1}
         end
     end,
@@ -140,3 +141,17 @@ to_complex(N) -> to_float(N).
 -spec to_float(number()) -> float().
 to_float(Integer) when is_integer(Integer) -> 0.0+Integer;
 to_float(Float) when is_float(Float) -> Float.
+
+%% +-*/
+'+'(Z) when is_number(Z) -> Z;
+'+'(Z) -> Z.
+'+'(Z0, Z1) when is_number(Z0), is_number(Z0) -> Z0 + Z1;
+'+'(Z0, Z1) -> sum(Z0, Z1).
+'-'(Z) when is_number(Z) -> -Z;
+'-'(Z) -> mltp(-1, Z).
+'-'(Z0, Z1) when is_number(Z0), is_number(Z0) -> Z0 - Z1;
+'-'(Z0, Z1) -> sum(Z0, mltp(-1, Z1)).
+'*'(Z0, Z1) when is_number(Z0), is_number(Z0) -> Z0 * Z1;
+'*'(Z0, Z1) -> mltp(Z0, Z1).
+'/'(Z0, Z1) when is_number(Z0), is_number(Z0) -> Z0 / Z1;
+'/'(Z0, Z1) -> mltp(Z0, reciprocal(Z1)).

--- a/src/linalg_roots.erl
+++ b/src/linalg_roots.erl
@@ -2,7 +2,7 @@
 -vsn('1.0').
 -author('simon.klassen').
 -import(linalg_complex, [sqrt/1, qbrt/1, absolute/1, usort/1]).
--import(linalg_complex, [add/1, add/2, mltp/1, mltp/2, reciprocal/1]).
+-import(linalg_complex, [sum/1, sum/2, mltp/1, mltp/2, reciprocal/1]).
 -export([roots/1]).
 -define(SMALL, 1.0e-10).
 
@@ -30,17 +30,17 @@ roots([A, B, C]) ->
     Denom = reciprocal(mltp(2,A)), % 1/(2*A)
     P = mltp([-1, B, Denom]), % -b/(2*A)
     % Q = sqrt(B^2-4*A*C)/(2*A)
-    Q = mltp(Denom, sqrt(add(mltp(B, B), mltp([-4, A, C])))),
-    usort([add(P, Q), add(P, mltp(-1, Q))]); % P +/- Q
+    Q = mltp(Denom, sqrt(sum(mltp(B, B), mltp([-4, A, C])))),
+    usort([sum(P, Q), sum(P, mltp(-1, Q))]); % P +/- Q
 % cubic polynomial
 % viete
 % x^3 + bx^2 + cx +d = 0
 roots([1, B, C, D]) ->
     P = mltp(-1/3, B), % -b/3
     % Q = (-2B^3+9BC-27D)/54
-    Q = mltp(1/54, add([mltp([-2,B,B,B]), mltp([9, B, C]), mltp(-27, D)])),
+    Q = mltp(1/54, sum([mltp([-2,B,B,B]), mltp([9, B, C]), mltp(-27, D)])),
     % R = sqrt(3*(27D^2-18BCD+4B^3D+4C^3-B^2C^2))/18
-    R = mltp(1/18, sqrt(mltp(3, add([
+    R = mltp(1/18, sqrt(mltp(3, sum([
         mltp([27,D,D]), mltp([-18,B,C,D]),
         mltp([4,B,B,B,D]), mltp([4,C,C,C]), mltp([-1,B,B,C,C])
     ])))),
@@ -50,13 +50,13 @@ roots([1, B, C, D]) ->
     
     % QpR = qbrt(Q+R)
     % QnR = qbrt(Q-R)
-    QpR0 = qbrt(add(Q, R)),
-    QnR0 = qbrt(add(Q, mltp(-1, R))),
+    QpR0 = qbrt(sum(Q, R)),
+    QnR0 = qbrt(sum(Q, mltp(-1, R))),
     QpRs = [QpR0, mltp(W,QpR0), mltp([W,W,QpR0])],
     QnRs = [QnR0, mltp(W,QnR0), mltp([W,W,QnR0])],
     
     % X = P + QpRs + QnRs
-    PossibleX = [add([P, QpR, QnR]) || QpR<-QpRs, QnR<-QnRs],
+    PossibleX = [sum([P, QpR, QnR]) || QpR<-QpRs, QnR<-QnRs],
     XList = lists:filter(roots_filter([1,B,C,D]), PossibleX),
     usort(XList);
 roots([A, B, C, D]) ->
@@ -66,7 +66,7 @@ roots([A, B, C, D]) ->
 roots_filter(Params) ->
     fun(X) ->
         FoldFun = fun(Param, {XpN, Ans}) ->
-            {mltp(XpN, X), add(Ans, mltp(Param, XpN))}
+            {mltp(XpN, X), sum(Ans, mltp(Param, XpN))}
         end,
         {_, Complex} = lists:foldr(FoldFun, {1, 0}, Params),
         absolute(Complex) < ?SMALL

--- a/test/linalg_complex_tests.erl
+++ b/test/linalg_complex_tests.erl
@@ -314,6 +314,7 @@ complex_usort_1_test() ->
     ))).
 
 complex_arithmetic_test() ->
+    ?assertEqual(complex_infinity, catch linalg:divide(1,0)),
     ?assertEqual([
         {6.0,8.0},
         {2.0,2.0},

--- a/test/linalg_complex_tests.erl
+++ b/test/linalg_complex_tests.erl
@@ -2,7 +2,7 @@
 -import(linalg_complex, [to_polar/1, from_polar/1]).
 -import(linalg_complex, [exp/1, ln/1, pow/2]).
 -import(linalg_complex, [sqrt/1, qbrt/1, absolute/1, arg/1, usort/1]).
--import(linalg_complex, [add/1, add/2, mltp/1, mltp/2, reciprocal/1]).
+-import(linalg_complex, [sum/1, sum/2, mltp/1, mltp/2, reciprocal/1]).
 -export([approx/1]).
 -define(NODEBUG, true). % Define NODEBUG for a quiet test.
 -include_lib("eunit/include/eunit.hrl").
@@ -313,17 +313,30 @@ complex_usort_1_test() ->
         [1,9,2,8,3,7,4,6,5,5,6,4,7,3,8,2,8.99999999999,1.00000000001]
     ))).
 
-complex_add_1_test() ->
-    ?assertEqual({7.0,8.0}, add([1, {2,0}, {0,3}, {4,5}])).
+complex_arithmetic_test() ->
+    ?assertEqual([
+        {6.0,8.0},
+        {2.0,2.0},
+        {-7.0,22.0},
+        {1.769231,-0.153846}
+    ], approx([
+        linalg:add({4,5}, {2,3}),
+        linalg:sub({4,5}, {2,3}),
+        linalg:mul({4,5}, {2,3}),
+        linalg:divide({4,5}, {2,3})
+    ])).
 
-complex_add_2_test() ->
-    ?assertEqual(3.0, add(1, 2)),
-    ?assertEqual(3.0, add({1,0}, 2)),
-    ?assertEqual(3.0, add(1, {2,0})),
-    ?assertEqual(3.0, add({1,0}, {2,0})),
-    ?assertEqual({3.0,9.0}, add({1,4}, {2,5})),
-    ?assertEqual({-4.0,2.0}, add({1,4}, {-5,-2})),
-    ?assertEqual({6.8,11.2}, add({1.2,3.4}, {5.6,7.8})).
+complex_sum_1_test() ->
+    ?assertEqual({7.0,8.0}, sum([1, {2,0}, {0,3}, {4,5}])).
+
+complex_sum_2_test() ->
+    ?assertEqual(3.0, sum(1, 2)),
+    ?assertEqual(3.0, sum({1,0}, 2)),
+    ?assertEqual(3.0, sum(1, {2,0})),
+    ?assertEqual(3.0, sum({1,0}, {2,0})),
+    ?assertEqual({3.0,9.0}, sum({1,4}, {2,5})),
+    ?assertEqual({-4.0,2.0}, sum({1,4}, {-5,-2})),
+    ?assertEqual({6.8,11.2}, sum({1.2,3.4}, {5.6,7.8})).
 
 complex_mltp_1_test() ->
     ?assertEqual([{-196.0,83.0}], approx([mltp([{2,3},{4,5},{6,7}])])).

--- a/test/linalg_roots_tests.erl
+++ b/test/linalg_roots_tests.erl
@@ -1,7 +1,7 @@
 -module(linalg_roots_tests).
 -import(linalg, [roots/1]).
 -import(linalg_complex_tests, [approx/1]).
--import(linalg_complex, [add/1, add/2, mltp/1, mltp/2, reciprocal/1]).
+-import(linalg_complex, [sum/2, mltp/2]).
 -define(NODEBUG, true). % Define NODEBUG for a quiet test.
 -include_lib("eunit/include/eunit.hrl").
 -define(SMALL, 1.0e-9).
@@ -52,12 +52,13 @@ roots_4_n_test() ->
     Range = lists:seq(-5,5),
     ParamsList = [[A,B,C,D]||A <- Range, B <- Range, C <- Range, D <- Range],
     assert_roots(ParamsList),
-    R = lists:seq(1,2) ++ lists:seq(-2,-1),
-    I = lists:seq(-2,2),
+    R = [-1,1,2],
+    I = [-1,0,1,2],
     ComplexParamsList = [[{Ar,Ai},{Br,Bi},{Cr,Ci},{Dr,Di}]
-        ||Ar<-R, Ai<-R, Br<-R, Bi<-R, Cr<-R, Ci<-R, Dr<-R, Di<-R
+        ||Ar<-R, Ai<-I, Br<-R, Bi<-I, Cr<-R, Ci<-I, Dr<-R, Di<-I
     ],
-    assert_roots(ComplexParamsList).
+    assert_roots(ComplexParamsList),
+    true.
 
 
 %% @doc Assert roots with any given params.
@@ -79,7 +80,7 @@ assert_roots(_Params, []) ->
 assert_roots(Params, [X|OtherRoots]) ->
     ?debugFmt("Params=~p, X=~p", [Params, X]),
     FoldFun = fun(Param, {XpN, Ans}) ->
-        {mltp(XpN, X), add(Ans, mltp(Param, XpN))}
+        {mltp(XpN, X), sum(Ans, mltp(Param, XpN))}
     end,
     Res = case lists:foldr(FoldFun, {1, 0}, Params) of
         {_, {R, I}} -> math:sqrt(R*R+I*I);


### PR DESCRIPTION
You can now `linalg:add({2,3}, {4,5})`.
Also `sub/2`, `mul2`, and `divide/2` of `linalg` module.